### PR TITLE
Encourage displayable names

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -66,6 +66,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
     },
     "clientInfo": {
       "name": "ExampleClient",
+      "displayName": "Example Client Display Name",
       "version": "1.0.0"
     }
   }
@@ -101,6 +102,7 @@ The server **MUST** respond with its own capabilities and information:
     },
     "serverInfo": {
       "name": "ExampleServer",
+      "displayName": "Example Server Display Name",
       "version": "1.0.0"
     },
     "instructions": "Optional instructions for the client"

--- a/docs/specification/draft/client/roots.mdx
+++ b/docs/specification/draft/client/roots.mdx
@@ -66,7 +66,7 @@ To retrieve roots, servers send a `roots/list` request:
     "roots": [
       {
         "uri": "file:///home/user/projects/myproject",
-        "name": "My Project"
+        "displayName": "My Project"
       }
     ]
   }
@@ -109,7 +109,7 @@ A root definition includes:
 
 - `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
   specification.
-- `name`: Optional human-readable name for display purposes.
+- `displayName`: Optional human-readable name for display purposes.
 
 Example roots for different use cases:
 
@@ -118,7 +118,7 @@ Example roots for different use cases:
 ```json
 {
   "uri": "file:///home/user/projects/myproject",
-  "name": "My Project"
+  "displayName": "My Project"
 }
 ```
 
@@ -128,11 +128,11 @@ Example roots for different use cases:
 [
   {
     "uri": "file:///home/user/repos/frontend",
-    "name": "Frontend Repository"
+    "displayName": "Front-end Repository"
   },
   {
     "uri": "file:///home/user/repos/backend",
-    "name": "Backend Repository"
+    "displayName": "Back-end Repository"
   }
 ]
 ```

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -73,6 +73,7 @@ supports [pagination](/specification/draft/server/utilities/pagination).
     "prompts": [
       {
         "name": "code_review",
+        "displayName": "Request Code Review",
         "description": "Asks the LLM to analyze code quality and suggest improvements",
         "arguments": [
           {
@@ -172,6 +173,7 @@ sequenceDiagram
 A prompt definition includes:
 
 - `name`: Unique identifier for the prompt
+- `displayName`: Optional human-readable name for display purposes.
 - `description`: Optional human-readable description
 - `arguments`: Optional list of arguments for customization
 
@@ -234,6 +236,7 @@ Embedded resources allow referencing server-side resources directly in messages:
   "type": "resource",
   "resource": {
     "uri": "resource://example",
+    "displayName": "My Example Resource",
     "mimeType": "text/plain",
     "text": "Resource content"
   }

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -111,6 +111,7 @@ supports [pagination](/specification/draft/server/utilities/pagination).
       {
         "uri": "file:///project/src/main.rs",
         "name": "main.rs",
+        "displayName": "main.rs",
         "description": "Primary application entry point",
         "mimeType": "text/x-rust"
       }
@@ -147,6 +148,7 @@ To retrieve resource contents, clients send a `resources/read` request:
     "contents": [
       {
         "uri": "file:///project/src/main.rs",
+        "displayName": "main.rs",
         "mimeType": "text/x-rust",
         "text": "fn main() {\n    println!(\"Hello world!\");\n}"
       }
@@ -182,6 +184,7 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
       {
         "uriTemplate": "file:///{path}",
         "name": "Project Files",
+        "displayName": "📁 Project Files",
         "description": "Access files in the project directory",
         "mimeType": "application/octet-stream"
       }
@@ -227,7 +230,8 @@ to specific resources and receive notifications when they change:
   "jsonrpc": "2.0",
   "method": "notifications/resources/updated",
   "params": {
-    "uri": "file:///project/src/main.rs"
+    "uri": "file:///project/src/main.rs",
+    "displayName": "main.rs"
   }
 }
 ```
@@ -264,7 +268,7 @@ sequenceDiagram
 A resource definition includes:
 
 - `uri`: Unique identifier for the resource
-- `name`: Human-readable name
+- `displayName`: Optional human-readable name for display purposes.
 - `description`: Optional description
 - `mimeType`: Optional MIME type
 - `size`: Optional size in bytes
@@ -278,6 +282,7 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.txt",
+  "displayName": "example.txt",
   "mimeType": "text/plain",
   "text": "Resource content"
 }
@@ -288,6 +293,7 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.png",
+  "displayName": "example.png",
   "mimeType": "image/png",
   "blob": "base64-encoded-data"
 }

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -78,6 +78,7 @@ To discover available tools, clients send a `tools/list` request. This operation
     "tools": [
       {
         "name": "get_weather",
+        "displayName": "Weather Getter",
         "description": "Get current weather information for a location",
         "inputSchema": {
           "type": "object",
@@ -179,6 +180,7 @@ sequenceDiagram
 A tool definition includes:
 
 - `name`: Unique identifier for the tool
+- `displayName`: Optional human-readable name for display purposes.
 - `description`: Human-readable description of functionality
 - `inputSchema`: JSON Schema defining expected parameters
 - `outputSchema`: Optional JSON Schema defining expected output structure
@@ -232,6 +234,7 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
   "type": "resource",
   "resource": {
     "uri": "resource://example",
+    "displayName": "My Plain-text Resource",
     "mimeType": "text/plain",
     "text": "Resource content"
   }
@@ -257,6 +260,7 @@ Example tool with output schema:
 ```json
 {
   "name": "get_weather_data",
+  "displayName": "Weather Data Retriever",
   "description": "Get current weather data for a location",
   "inputSchema": {
     "type": "object",


### PR DESCRIPTION
Encourage displayName properties/usage for objects/resources likely to be represented in a UI

## Summary by Sourcery

Enhancements:
- Standardize on `displayName` as the optional human-readable name in spec definitions and examples for roots, resources, tools, prompts, and client/server info.