### PR TITLE
Encourage display names

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -66,6 +66,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
     },
     "clientInfo": {
       "name": "ExampleClient",
+      "displayName": "Example Client Display Name",
       "version": "1.0.0"
     }
   }
@@ -101,6 +102,7 @@ The server **MUST** respond with its own capabilities and information:
     },
     "serverInfo": {
       "name": "ExampleServer",
+      "displayName": "Example Server Display Name",
       "version": "1.0.0"
     },
     "instructions": "Optional instructions for the client"

--- a/docs/specification/draft/client/roots.mdx
+++ b/docs/specification/draft/client/roots.mdx
@@ -109,7 +109,8 @@ A root definition includes:
 
 - `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
   specification.
-- `name`: Optional human-readable name for display purposes.
+- `name`: Optional human-readable name of the root.
+- `displayName`: Optional human-readable name of the root used for display purposes.
 
 Example roots for different use cases:
 
@@ -118,7 +119,8 @@ Example roots for different use cases:
 ```json
 {
   "uri": "file:///home/user/projects/myproject",
-  "name": "My Project"
+  "name": "myproject",
+  "displayName": "My Project"
 }
 ```
 
@@ -128,11 +130,13 @@ Example roots for different use cases:
 [
   {
     "uri": "file:///home/user/repos/frontend",
-    "name": "Frontend Repository"
+    "name": "frontend",
+    "displayName": "Front-end Repository"
   },
   {
     "uri": "file:///home/user/repos/backend",
-    "name": "Backend Repository"
+    "name": "backend",
+    "displayName": "Back-end Repository",
   }
 ]
 ```

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -73,6 +73,7 @@ supports [pagination](/specification/draft/server/utilities/pagination).
     "prompts": [
       {
         "name": "code_review",
+        "displayName": "Request Code Review",
         "description": "Asks the LLM to analyze code quality and suggest improvements",
         "arguments": [
           {
@@ -172,6 +173,7 @@ sequenceDiagram
 A prompt definition includes:
 
 - `name`: Unique identifier for the prompt
+- `displayName`: Optional human-readable name of the prompt for display purposes.
 - `description`: Optional human-readable description
 - `arguments`: Optional list of arguments for customization
 
@@ -234,6 +236,8 @@ Embedded resources allow referencing server-side resources directly in messages:
   "type": "resource",
   "resource": {
     "uri": "resource://example",
+    "name": "example",
+    "displayName": "My Example Resource",
     "mimeType": "text/plain",
     "text": "Resource content"
   }

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -111,6 +111,7 @@ supports [pagination](/specification/draft/server/utilities/pagination).
       {
         "uri": "file:///project/src/main.rs",
         "name": "main.rs",
+        "displayName": "main.rs",
         "description": "Primary application entry point",
         "mimeType": "text/x-rust"
       }
@@ -147,6 +148,8 @@ To retrieve resource contents, clients send a `resources/read` request:
     "contents": [
       {
         "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "displayName": "main.rs",
         "mimeType": "text/x-rust",
         "text": "fn main() {\n    println!(\"Hello world!\");\n}"
       }
@@ -182,6 +185,7 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
       {
         "uriTemplate": "file:///{path}",
         "name": "Project Files",
+        "displayName": "📁 Project Files",
         "description": "Access files in the project directory",
         "mimeType": "application/octet-stream"
       }
@@ -227,7 +231,8 @@ to specific resources and receive notifications when they change:
   "jsonrpc": "2.0",
   "method": "notifications/resources/updated",
   "params": {
-    "uri": "file:///project/src/main.rs"
+    "uri": "file:///project/src/main.rs",
+    "displayName": "main.rs"
   }
 }
 ```
@@ -264,7 +269,8 @@ sequenceDiagram
 A resource definition includes:
 
 - `uri`: Unique identifier for the resource
-- `name`: Human-readable name
+- `name`: The name of the resource.
+- `displayName`: Optional human-readable name of the resource for display purposes.
 - `description`: Optional description
 - `mimeType`: Optional MIME type
 - `size`: Optional size in bytes
@@ -278,6 +284,8 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.txt",
+  "name": "example.txt",
+  "displayName": "Example Text File",
   "mimeType": "text/plain",
   "text": "Resource content"
 }
@@ -288,6 +296,8 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.png",
+  "name": "example.png",
+  "displayName": "Example Image",
   "mimeType": "image/png",
   "blob": "base64-encoded-data"
 }

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -78,6 +78,7 @@ To discover available tools, clients send a `tools/list` request. This operation
     "tools": [
       {
         "name": "get_weather",
+        "displayName": "Weather Information Provider",
         "description": "Get current weather information for a location",
         "inputSchema": {
           "type": "object",
@@ -179,6 +180,7 @@ sequenceDiagram
 A tool definition includes:
 
 - `name`: Unique identifier for the tool
+- `displayName`: Optional human-readable name of the tool for display purposes.
 - `description`: Human-readable description of functionality
 - `inputSchema`: JSON Schema defining expected parameters
 - `outputSchema`: Optional JSON Schema defining expected output structure
@@ -232,6 +234,7 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
   "type": "resource",
   "resource": {
     "uri": "resource://example",
+    "displayName": "My Plain-text Resource",
     "mimeType": "text/plain",
     "text": "Resource content"
   }
@@ -257,6 +260,7 @@ Example tool with output schema:
 ```json
 {
   "name": "get_weather_data",
+  "displayName": "Weather Data Retriever",
   "description": "Get current weather data for a location",
   "inputSchema": {
     "type": "object",

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -732,8 +732,11 @@
             "type": "object"
         },
         "Implementation": {
-            "description": "Describes the name and version of an MCP implementation.",
+            "description": "Describes the name and version of an MCP implementation, with an optional displayName for UI representation.",
             "properties": {
+                "displayName": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1540,8 +1543,12 @@
                     "description": "An optional description of what this prompt provides",
                     "type": "string"
                 },
+                "displayName": {
+                    "description": "An optional display name for the prompt or prompt template intended to be used for display purposes only.\nIt should be human-readable and may be different from the name.\n\nIf it is not provided, the name will be used for display.",
+                    "type": "string"
+                },
                 "name": {
-                    "description": "The name of the prompt or prompt template.",
+                    "description": "The unique identifier of the prompt or prompt template.",
                     "type": "string"
                 }
             },
@@ -1740,12 +1747,16 @@
                     "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
                 },
+                "displayName": {
+                    "description": "An optional display name for the resource intended for display purposes only. \nIt should be human-readable and may be different from the name.\n\nIf it is not provided, the name will be used for display.",
+                    "type": "string"
+                },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
                 "name": {
-                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+                    "description": "A name for this resource, used for display if no displayName is provided.",
                     "type": "string"
                 },
                 "size": {
@@ -1905,8 +1916,12 @@
         "Root": {
             "description": "Represents a root directory or file that the server can operate on.",
             "properties": {
+                "displayName": {
+                    "description": "An optional display name for the root intended to be used for display purposes only.\nIt should be human-readable and may be different from the name.\n\nIf not provided, the name (if provided) will be used as the display name.",
+                    "type": "string"
+                },
                 "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root (if a displayName is not provdied), which may be useful for display\npurposes or for referencing the root in other parts of the application.",
                     "type": "string"
                 },
                 "uri": {
@@ -2245,6 +2260,10 @@
                 },
                 "description": {
                     "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "An optional display name for the tool intended to be used for display purposes only.\nIt should be human-readable and may be different from the name.\n\nIf it is not provided, the name will be used for display.",
                     "type": "string"
                 },
                 "inputSchema": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -276,10 +276,11 @@ export interface ServerCapabilities {
 }
 
 /**
- * Describes the name and version of an MCP implementation.
+ * Describes the name and version of an MCP implementation, with an optional displayName for UI representation.
  */
 export interface Implementation {
   name: string;
+  displayName?: string;
   version: string;
 }
 
@@ -455,11 +456,17 @@ export interface Resource {
   uri: string;
 
   /**
-   * A human-readable name for this resource.
-   *
-   * This can be used by clients to populate UI elements.
+   * A name for this resource, used for display if no displayName is provided.
    */
   name: string;
+
+  /**
+   * An optional display name for the resource intended for display purposes only. 
+   * It should be human-readable and may be different from the name.
+   *
+   * If it is not provided, the name will be used for display.
+   */
+  displayName?: string;
 
   /**
    * A description of what this resource represents.
@@ -602,9 +609,16 @@ export interface GetPromptResult extends Result {
  */
 export interface Prompt {
   /**
-   * The name of the prompt or prompt template.
+   * The unique identifier of the prompt or prompt template.
    */
   name: string;
+  /**
+   * An optional display name for the prompt or prompt template intended to be used for display purposes only.
+   * It should be human-readable and may be different from the name.
+   *
+   * If it is not provided, the name will be used for display.
+   */
+  displayName?: string;
   /**
    * An optional description of what this prompt provides
    */
@@ -798,6 +812,14 @@ export interface Tool {
    * The name of the tool.
    */
   name: string;
+
+  /**
+   * An optional display name for the tool intended to be used for display purposes only.
+   * It should be human-readable and may be different from the name.
+   *
+   * If it is not provided, the name will be used for display.
+   */
+  displayName?: string;
 
   /**
    * A human-readable description of the tool.
@@ -1215,10 +1237,17 @@ export interface Root {
   uri: string;
   /**
    * An optional name for the root. This can be used to provide a human-readable
-   * identifier for the root, which may be useful for display purposes or for
-   * referencing the root in other parts of the application.
+   * identifier for the root (if a displayName is not provdied), which may be useful for display
+   * purposes or for referencing the root in other parts of the application.
    */
   name?: string;
+  /**
+   * An optional display name for the root intended to be used for display purposes only.
+   * It should be human-readable and may be different from the name.
+   *
+   * If not provided, the name (if provided) will be used as the display name.
+   */
+  displayName?: string;
 }
 
 /**


### PR DESCRIPTION
Encourage displayName properties/usage for objects/resources likely to be represented in a UI

## Summary by Sourcery

Encourage UI-friendly naming by introducing an optional displayName property across the specification and updating all related examples to include it.

Enhancements:
- Encourage displayName usage for objects and resources likely to appear in a UI.

Documentation:
- Add optional displayName field to resource, tool, prompt, clientInfo, and serverInfo definitions in the spec.
- Update JSON examples and sequence diagrams to include displayName entries for resources, tools, prompts, and lifecycle messages.
- Correct example root labels to “Front-end Repository” and “Back-end Repository” for consistency.